### PR TITLE
Suporte inicial a ScriptableObjects

### DIFF
--- a/Assets/Resources/Itens.meta
+++ b/Assets/Resources/Itens.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a03810112d85cd64eaf146afa11c9784
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Escudo de Madeira.asset
+++ b/Assets/Resources/Itens/Escudo de Madeira.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6908b23cb73a8d48960d3e4a02c5e4a, type: 3}
+  m_Name: Escudo de Madeira
+  m_EditorClassIdentifier: 
+  id: 0
+  name: 
+  itemType: 0
+  damageValue: 0
+  defenseValue: 0

--- a/Assets/Resources/Itens/Escudo de Madeira.asset.meta
+++ b/Assets/Resources/Itens/Escudo de Madeira.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1171c2a5f17ff974187bb0427bed1fe3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Escudo do Dragão.asset
+++ b/Assets/Resources/Itens/Escudo do Dragão.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6908b23cb73a8d48960d3e4a02c5e4a, type: 3}
+  m_Name: "Escudo do Drag\xE3o"
+  m_EditorClassIdentifier: 
+  id: 0
+  itemType: 0
+  damageValue: 0
+  defenseValue: 0

--- a/Assets/Resources/Itens/Escudo do Dragão.asset.meta
+++ b/Assets/Resources/Itens/Escudo do Dragão.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31b34db9bec41204f940d36a04e664b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Espada Longa.asset
+++ b/Assets/Resources/Itens/Espada Longa.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6908b23cb73a8d48960d3e4a02c5e4a, type: 3}
+  m_Name: New Item 1
+  m_EditorClassIdentifier: 
+  id: 0
+  name: 
+  itemType: 0
+  damageValue: 0
+  defenseValue: 0

--- a/Assets/Resources/Itens/Espada Longa.asset.meta
+++ b/Assets/Resources/Itens/Espada Longa.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 984e6016679d41f4a9644f644244a89d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Espada S.asset
+++ b/Assets/Resources/Itens/Espada S.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6908b23cb73a8d48960d3e4a02c5e4a, type: 3}
+  m_Name: New Item
+  m_EditorClassIdentifier: 
+  id: 0
+  name: 
+  itemType: 0

--- a/Assets/Resources/Itens/Espada S.asset.meta
+++ b/Assets/Resources/Itens/Espada S.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8963a6ce4118cff4a8e4f863a96e38bc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Espada de Fogo.asset
+++ b/Assets/Resources/Itens/Espada de Fogo.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6908b23cb73a8d48960d3e4a02c5e4a, type: 3}
+  m_Name: Espada de Fogo
+  m_EditorClassIdentifier: 
+  id: 0
+  name: 
+  itemType: 0
+  damageValue: 0
+  defenseValue: 0

--- a/Assets/Resources/Itens/Espada de Fogo.asset.meta
+++ b/Assets/Resources/Itens/Espada de Fogo.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ceace75e27e452419786ab11ec09dab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Item Types.meta
+++ b/Assets/Resources/Itens/Item Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab186e3adf666224ca9f1515a1d205bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Item Types/Shield.asset
+++ b/Assets/Resources/Itens/Item Types/Shield.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be9ffd8a1d5c44e2aedbc7d4109c2189, type: 3}
+  m_Name: Shield
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Itens/Item Types/Shield.asset.meta
+++ b/Assets/Resources/Itens/Item Types/Shield.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3bd02707e64b9a348ac33635c386bd25
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Itens/Item Types/Sword.asset
+++ b/Assets/Resources/Itens/Item Types/Sword.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be9ffd8a1d5c44e2aedbc7d4109c2189, type: 3}
+  m_Name: Sword
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Itens/Item Types/Sword.asset.meta
+++ b/Assets/Resources/Itens/Item Types/Sword.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dde0fd9be35002c4a8bd54bebbeeb409
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Behaviours/Item.cs
+++ b/Assets/Script/Behaviours/Item.cs
@@ -1,37 +1,25 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-
-
+﻿using UnityEngine;
 
 public class Item : MonoBehaviour
 {
 
-    public int id;
-    public string nome;
-    public string tipo;  
-    public int dano;
-    public int defesa;
+    [HideInInspector] public int id;
+    [HideInInspector] public string nome;
+    [HideInInspector] public string tipo;
+    [HideInInspector] public int dano;
+    [HideInInspector] public int defesa;
 
     // Start is called before the first frame update
-    void Start()
+    private void Start()
     {
         // colocando o nome do prefab com o nome do item
         name = nome;
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
-
-    void OnGUI()
+    private void OnGUI()
     {
         //Use a Câmera Principal e obtenha a posição do objeto atual
-        Vector3 screenPos = Camera.main.WorldToScreenPoint(this.transform.position);
+        var screenPos = Camera.main.WorldToScreenPoint(this.transform.position);
         //Cria o label
         GUI.Label(new Rect(screenPos.x, Screen.height - screenPos.y, 100, 50), nome);
     }

--- a/Assets/Script/Gerenciadores/LeitorCSVScript.cs
+++ b/Assets/Script/Gerenciadores/LeitorCSVScript.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 public class LeitorCSVScript : MonoBehaviour
 {
- 
     public GameObject prefDungeon;
     public GameObject listaDeDungeon;
 
@@ -12,24 +11,24 @@ public class LeitorCSVScript : MonoBehaviour
 
     void Awake()
     {
-
         gerenciador = gameObject.GetComponent<GerenciadorScript>();
 
-        if(gerenciador == null) {
+        if (gerenciador == null)
+        {
             Debug.Log("gerenciador null no Leitor de CSV");
-        } else { 
+        }
+        else
+        {
             //se não for nulo, carrega a Dungeon e os Personagens
-            carregaDungeon(); 
+            carregaDungeon();
             carregaPersonagens();
             carregaItens();
         }
-
     }
 
     // função que carrega todos os personagens do CSV
     void carregaPersonagens()
     {
-
         //nome do arquivo dos personagens é Personagens, ele deve estar dentro na pastas
         // Resouces
         TextAsset leArquivo = Resources.Load<TextAsset>("Personagens");
@@ -42,8 +41,6 @@ public class LeitorCSVScript : MonoBehaviour
         {
             Debug.Log("leu arquivo de csv Personagem");
         }
-
-
 
 
         string[] data = leArquivo.text.Split('\n');
@@ -67,59 +64,29 @@ public class LeitorCSVScript : MonoBehaviour
                 //estou utilizando o JsonHelper para converter em array. O normal não tem essa função
                 itens = JsonHelper.FromJson<int>(valor[6]),
                 dropChance = int.Parse(valor[7])
-
             };
 
             //adiciona na lista
             gerenciador.inimigos.Add(inimigo);
-
-        } 
-
+        }
     }
 
     // função que carrega todos os itens do CSV
     void carregaItens()
     {
-
-        //nome do arquivo dos itens é Itens, ele deve estar dentro na pastas
-        // Resouces
-        TextAsset leArquivo = Resources.Load<TextAsset>("Itens");
-
-        if (leArquivo == null)
+        foreach (var item in Resources.FindObjectsOfTypeAll<RPG.Item>())
         {
-            Debug.Log("não leu arquivo no gerenciador Itens");
-        }
-        else
-        {
-            Debug.Log("leu arquivo de csv Itens");
-        }
-         
-
-        string[] data = leArquivo.text.Split('\n');
-
-        //começa pelo 1 pq ele avisa quais são meus parametros;
-        for (int i = 1; i < data.Length; i++)
-        {
-            //Debug.Log(data[i]);
-            string[] valor = data[i].Split(';');
-
-            //cria Itens (classe) na lista- não temos o prefb dele ainda
-            Item item = new Item
+            var newItem = new Item
             {
-                //seta os valores
-                id = int.Parse(valor[0]),
-                nome = valor[1],
-                tipo = valor[2],
-                dano = int.Parse(valor[3]),
-                defesa = int.Parse(valor[4]),
-                  
+                id = item.id,
+                nome = item.itemName,
+                tipo = item.itemType.name,
+                dano = item.damageValue,
+                defesa = item.defenseValue
             };
-
-            //adiciona na lista
-            gerenciador.itens.Add(item);
-
+            
+            gerenciador.itens.Add(newItem);
         }
-
     }
 
     // função que carrega todas as Dungeons do CSV
@@ -144,7 +111,6 @@ public class LeitorCSVScript : MonoBehaviour
         }
 
 
-
         string[] data = leArquivo.text.Split('\n');
 
         //começa pelo 1 pq ele avisa quais são meus parametros;
@@ -161,10 +127,10 @@ public class LeitorCSVScript : MonoBehaviour
             prefDungeon.GetComponent<Dungeon>().qtdade = int.Parse(valor[4]);
             prefDungeon.GetComponent<Dungeon>().tempoDeSpawn = int.Parse(valor[5]);
             prefDungeon.GetComponent<Dungeon>().nome = valor[6];
-           
+
 
             //cria a dungeon
-            Instantiate(prefDungeon, listaDeDungeon.transform);  
+            Instantiate(prefDungeon, listaDeDungeon.transform);
 
             //adiciona a dungeon na lista
             gerenciador.dungeons.Add(prefDungeon.GetComponent<Dungeon>());

--- a/Assets/Script/Item.cs
+++ b/Assets/Script/Item.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+namespace RPG
+{
+    [CreateAssetMenu(menuName = "Item/New Item", fileName = "New Item")]
+    public class Item : ScriptableObject
+    {
+        public int id;
+        public string itemName;
+        public ItemType itemType;
+        public int damageValue;
+        public int defenseValue;
+    }
+
+}

--- a/Assets/Script/Item.cs.meta
+++ b/Assets/Script/Item.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6908b23cb73a8d48960d3e4a02c5e4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/ItemType.cs
+++ b/Assets/Script/ItemType.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace RPG
+{
+    [CreateAssetMenu(menuName = "Item/New Item Type", fileName = "New Item Type")]
+    public class ItemType : ScriptableObject
+    {
+    }
+}

--- a/Assets/Script/ItemType.cs.meta
+++ b/Assets/Script/ItemType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: be9ffd8a1d5c44e2aedbc7d4109c2189
+timeCreated: 1563797714

--- a/Logs/Packages-Update.log
+++ b/Logs/Packages-Update.log
@@ -57,3 +57,11 @@ The following packages were updated:
   com.unity.package-manager-ui from version 2.0.3 to 2.1.2
   com.unity.purchasing from version 2.0.3 to 2.0.6
   com.unity.textmeshpro from version 1.3.0 to 2.0.0
+
+=== Sat Jul 20 20:18:28 2019
+
+Packages were changed.
+Update Mode: updateDependencies
+
+The following packages were updated:
+  com.unity.package-manager-ui from version 2.0.3 to 2.0.7

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.2.2",
     "com.unity.collab-proxy": "1.2.15",
-    "com.unity.package-manager-ui": "2.0.3",
+    "com.unity.package-manager-ui": "2.0.7",
     "com.unity.purchasing": "2.0.3",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.7f1
+m_EditorVersion: 2018.4.4f1


### PR DESCRIPTION
Olá @Cherobin!

Eu vi seu projeto e quero sugerir essa alteração: **usar ScriptableObjects ao invés de dados armazenados em CSV**. Para dar início, eu substituí todo o sistema atual de itens por um baseado em ScriptableObjects.

### Por quê?
Com ScriptableObjects, desginers e desenvolvedores que não sabem programar podem criar novos itens para o jogo direto da interface do editor da Unity (através do menu Assets > Create > "Nome do ScriptableObject"), sem precisar de programas externos.

Como esses objetos não "vivem" dentro de uma cena do jogo eles podem ser alterados durante o modo Play do editor sem perder suas alterações. Isso é uma mão na roda para trabalhar o balanceamento de uma fase, por exemplo.

Esse tipo de asset pode ser serializado/deserializado em um JSON também, facilitando o armazenamento e compartilhamento, quando se fala de um jogo online.

Por fim, acho que é bem legal quando outras pessoas podem criar alterações e adições significativas em um jogo sem precisar depender do "programador da equipe". Torna o design do jogo mais inclusivo.

### Mais informações sobre ScriptableObjects
https://unity3d.com/pt/how-to/architect-with-scriptable-objects